### PR TITLE
Move linguist-generated to the root directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,5 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+ThScoreFileConverter/Templates/*.html linguist-generated=true

--- a/ThScoreFileConverter/Templates/.gitattributes
+++ b/ThScoreFileConverter/Templates/.gitattributes
@@ -1,1 +1,0 @@
-*.html linguist-generated=true


### PR DESCRIPTION
Fixes #25 again because specifying it in a subdirectory has no effect.