### PR TITLE
Revert "Bump WpfAnalyzers from 3.1.1 to 3.2.0"

### DIFF
--- a/ThScoreFileConverter/ThScoreFileConverter.csproj
+++ b/ThScoreFileConverter/ThScoreFileConverter.csproj
@@ -81,7 +81,7 @@
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
-    <PackageReference Include="WpfAnalyzers" Version="3.2.0">
+    <PackageReference Include="WpfAnalyzers" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Reverts #51 to avoid too many AD0001 warnings: Could not load file or assembly Gu.Roslyn.Extensions.

As described in DotNetAnalyzers/PropertyChangedAnalyzers#111, it seems to be due to two different versions of Gu.Roslyn.Extensions:
* 0.12.9-dev on which IDisposableAnalyzers 3.4.2 depends, and
* 0.13.2 on which WpfAnalyzers 3.2.0 depends.

So I continue to use WpfAnalyzers 3.1.1, which depends on 0.12.9-dev, until IDisposableAnalyzers is updated.