### PR TITLE
Migrate to FOSSA CI/CD Scanning

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,26 @@
+# Refer to the following for details:
+# https://github.com/fossas/fossa-cli/blob/master/docs/config-file.md#fossayml
+
+version: 2
+cli:
+  server: https://app.fossa.com
+  fetcher: custom
+  project: ThScoreFileConverter
+analyze:
+  modules:
+  - name: TemplateGenerator
+    type: nuget
+    target: TemplateGenerator\TemplateGenerator.csproj
+    path: TemplateGenerator
+  - name: ThScoreFileConverter
+    type: nuget
+    target: ThScoreFileConverter\ThScoreFileConverter.csproj
+    path: ThScoreFileConverter
+  - name: ThScoreFileConverterTests
+    type: nuget
+    target: ThScoreFileConverterTests\ThScoreFileConverterTests.csproj
+    path: ThScoreFileConverterTests
+  - name: ManualGenerator
+    type: pip
+    target: ManualGenerator
+    path: ManualGenerator

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -4,8 +4,8 @@
 version: 2
 cli:
   server: https://app.fossa.com
-  fetcher: custom
-  project: ThScoreFileConverter
+  fetcher: git
+  locator: git+github.com/y-iihoshi/ThScoreFileConverter$revision
 analyze:
   modules:
   - name: TemplateGenerator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,13 @@ jobs:
         file: ThScoreFileConverterTests/coverage.${{ matrix.target-framework }}.xml
       if: matrix.configuration == 'Debug'
 
+    - name: Run FOSSA scan and upload build data
+      uses: fossa-contrib/fossa-action@v1.1.4
+      with:
+        fossa-api-key: 546ea14e5b1c4a901201f2d1cfc44a83   # Push only API token
+        skip-test: false
+      if: matrix.configuration == 'Debug'
+
     - name: Collect artifacts
       run: CollectArtifacts.bat ${{ matrix.configuration }} ${{ matrix.target-framework }}
       shell: cmd


### PR DESCRIPTION
To avoid annoying too many licensing issues caused by the Repository Scanning.