### PR TITLE
Fix to avoid confusion about UTF-8 encoding

### DIFF
--- a/ThScoreFileConverter/Helpers/EncodingHelper.cs
+++ b/ThScoreFileConverter/Helpers/EncodingHelper.cs
@@ -20,6 +20,7 @@ namespace ThScoreFileConverter.Helpers
 
             CP932 = System.Text.Encoding.GetEncoding(932);
             Default = System.Text.Encoding.Default;
+            UTF8 = System.Text.Encoding.UTF8;
             UTF8NoBOM = new System.Text.UTF8Encoding(false);
             Encodings = new Dictionary<int, System.Text.Encoding>();
         }
@@ -33,6 +34,11 @@ namespace ThScoreFileConverter.Helpers
         /// Gets the default encoding.
         /// </summary>
         public static System.Text.Encoding Default { get; }
+
+        /// <summary>
+        /// Gets the UTF-8 encoding. The Unicode byte order mark is emitted.
+        /// </summary>
+        public static System.Text.Encoding UTF8 { get; }
 
         /// <summary>
         /// Gets the UTF-8 encoding. The Unicode byte order mark is omitted.

--- a/ThScoreFileConverter/Helpers/EncodingHelper.cs
+++ b/ThScoreFileConverter/Helpers/EncodingHelper.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="Encoding.cs" company="None">
+// <copyright file="EncodingHelper.cs" company="None">
 // Copyright (c) IIHOSHI Yoshinori.
 // Licensed under the BSD-2-Clause license. See LICENSE.txt file in the project root for full license information.
 // </copyright>
@@ -7,14 +7,14 @@
 
 using System.Collections.Generic;
 
-namespace ThScoreFileConverter.Models
+namespace ThScoreFileConverter.Helpers
 {
     /// <summary>
     /// Contains read-only instances of <see cref="System.Text.Encoding"/> class for convenience.
     /// </summary>
-    public static class Encoding
+    public static class EncodingHelper
     {
-        static Encoding()
+        static EncodingHelper()
         {
             System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
 

--- a/ThScoreFileConverter/Helpers/EncodingHelper.cs
+++ b/ThScoreFileConverter/Helpers/EncodingHelper.cs
@@ -20,7 +20,7 @@ namespace ThScoreFileConverter.Helpers
 
             CP932 = System.Text.Encoding.GetEncoding(932);
             Default = System.Text.Encoding.Default;
-            UTF8 = new System.Text.UTF8Encoding(false);
+            UTF8NoBOM = new System.Text.UTF8Encoding(false);
             Encodings = new Dictionary<int, System.Text.Encoding>();
         }
 
@@ -37,7 +37,7 @@ namespace ThScoreFileConverter.Helpers
         /// <summary>
         /// Gets the UTF-8 encoding. The Unicode byte order mark is omitted.
         /// </summary>
-        public static System.Text.Encoding UTF8 { get; }
+        public static System.Text.Encoding UTF8NoBOM { get; }
 
         /// <summary>
         /// Gets the dictionary caching <see cref="System.Text.Encoding"/> instances.
@@ -55,7 +55,7 @@ namespace ThScoreFileConverter.Helpers
                 return encoding;
 
             // To prevent BOM output for UTF-8
-            encoding = (codePage == 65001) ? UTF8 : System.Text.Encoding.GetEncoding(codePage);
+            encoding = (codePage == 65001) ? UTF8NoBOM : System.Text.Encoding.GetEncoding(codePage);
             Encodings.Add(codePage, encoding);
             return encoding;
         }

--- a/ThScoreFileConverter/Models/BestShotDeveloper.cs
+++ b/ThScoreFileConverter/Models/BestShotDeveloper.cs
@@ -37,7 +37,7 @@ namespace ThScoreFileConverter.Models
 
             using var decoded = new MemoryStream();
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var header = BinaryReadableHelper.Create<THeader>(reader);
 
             Lzss.Decompress(input, decoded);

--- a/ThScoreFileConverter/Models/BestShotDeveloper.cs
+++ b/ThScoreFileConverter/Models/BestShotDeveloper.cs
@@ -37,7 +37,7 @@ namespace ThScoreFileConverter.Models
 
             using var decoded = new MemoryStream();
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var header = BinaryReadableHelper.Create<THeader>(reader);
 
             Lzss.Decompress(input, decoded);

--- a/ThScoreFileConverter/Models/Th06/Chapter.cs
+++ b/ThScoreFileConverter/Models/Th06/Chapter.cs
@@ -11,6 +11,7 @@ using System;
 using System.IO;
 using System.Linq;
 using ThScoreFileConverter.Extensions;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Properties;
 
 namespace ThScoreFileConverter.Models.Th06
@@ -62,7 +63,7 @@ namespace ThScoreFileConverter.Models.Th06
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(4));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(4));
             this.Size1 = reader.ReadInt16();
             this.Size2 = reader.ReadInt16();
             this.Data = reader.ReadExactBytes(this.Size1 - this.Signature.Length - (sizeof(short) * 2));

--- a/ThScoreFileConverter/Models/Th06/HighScore.cs
+++ b/ThScoreFileConverter/Models/Th06/HighScore.cs
@@ -41,7 +41,7 @@ namespace ThScoreFileConverter.Models.Th06
             : base()
         {
             this.Score = score;
-            this.Name = Encoding.Default.GetBytes("Nanashi\0\0");
+            this.Name = EncodingHelper.Default.GetBytes("Nanashi\0\0");
         }
 
         public uint Score { get; }

--- a/ThScoreFileConverter/Models/Th06/ScoreReplacer.cs
+++ b/ThScoreFileConverter/Models/Th06/ScoreReplacer.cs
@@ -47,7 +47,7 @@ namespace ThScoreFileConverter.Models.Th06
 
                 return type switch
                 {
-                    1 => Encoding.Default.GetString(score.Name.ToArray()).Split('\0')[0],
+                    1 => EncodingHelper.Default.GetString(score.Name.ToArray()).Split('\0')[0],
                     2 => formatter.FormatNumber(score.Score),
                     3 => score.StageProgress.ToShortName(),
                     _ => match.ToString(),  // unreachable

--- a/ThScoreFileConverter/Models/Th06Converter.cs
+++ b/ThScoreFileConverter/Models/Th06Converter.cs
@@ -96,8 +96,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -123,7 +123,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
             var chapter = new Chapter();
 
@@ -172,7 +172,7 @@ namespace ThScoreFileConverter.Models
                 { PracticeScore.ValidSignature, (data, ch) => data.Set(new PracticeScore(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Chapter();
 

--- a/ThScoreFileConverter/Models/Th06Converter.cs
+++ b/ThScoreFileConverter/Models/Th06Converter.cs
@@ -96,8 +96,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -123,7 +123,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var header = new FileHeader();
             var chapter = new Chapter();
 
@@ -172,7 +172,7 @@ namespace ThScoreFileConverter.Models
                 { PracticeScore.ValidSignature, (data, ch) => data.Set(new PracticeScore(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Chapter();
 

--- a/ThScoreFileConverter/Models/Th07/HighScore.cs
+++ b/ThScoreFileConverter/Models/Th07/HighScore.cs
@@ -44,8 +44,8 @@ namespace ThScoreFileConverter.Models.Th07
             : base()
         {
             this.Score = score;
-            this.Name = Encoding.Default.GetBytes("--------\0");
-            this.Date = Encoding.Default.GetBytes("--/--\0");
+            this.Name = EncodingHelper.Default.GetBytes("--------\0");
+            this.Date = EncodingHelper.Default.GetBytes("--/--\0");
         }
 
         public uint Score { get; }  // Divided by 10

--- a/ThScoreFileConverter/Models/Th07/ScoreReplacer.cs
+++ b/ThScoreFileConverter/Models/Th07/ScoreReplacer.cs
@@ -47,10 +47,10 @@ namespace ThScoreFileConverter.Models.Th07
 
                 return type switch
                 {
-                    1 => Encoding.Default.GetString(score.Name.ToArray()).Split('\0')[0],
+                    1 => EncodingHelper.Default.GetString(score.Name.ToArray()).Split('\0')[0],
                     2 => formatter.FormatNumber((score.Score * 10) + score.ContinueCount),
                     3 => score.StageProgress.ToShortName(),
-                    4 => Encoding.Default.GetString(score.Date.ToArray()).TrimEnd('\0'),
+                    4 => EncodingHelper.Default.GetString(score.Date.ToArray()).TrimEnd('\0'),
                     5 => formatter.FormatPercent(score.SlowRate, 3),
                     _ => match.ToString(),  // unreachable
                 };

--- a/ThScoreFileConverter/Models/Th075Converter.cs
+++ b/ThScoreFileConverter/Models/Th075Converter.cs
@@ -65,7 +65,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th075Converter.cs
+++ b/ThScoreFileConverter/Models/Th075Converter.cs
@@ -65,7 +65,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th07Converter.cs
+++ b/ThScoreFileConverter/Models/Th07Converter.cs
@@ -98,8 +98,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -119,7 +119,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var header = new FileHeader();
             var chapter = new Th06.Chapter();
 
@@ -176,7 +176,7 @@ namespace ThScoreFileConverter.Models
                 { VersionInfo.ValidSignature,   (data, ch) => data.Set(new VersionInfo(ch))   },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th06.Chapter();
 

--- a/ThScoreFileConverter/Models/Th07Converter.cs
+++ b/ThScoreFileConverter/Models/Th07Converter.cs
@@ -98,8 +98,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -119,7 +119,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
             var chapter = new Th06.Chapter();
 
@@ -176,7 +176,7 @@ namespace ThScoreFileConverter.Models
                 { VersionInfo.ValidSignature,   (data, ch) => data.Set(new VersionInfo(ch))   },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th06.Chapter();
 

--- a/ThScoreFileConverter/Models/Th08/HighScore.cs
+++ b/ThScoreFileConverter/Models/Th08/HighScore.cs
@@ -65,8 +65,8 @@ namespace ThScoreFileConverter.Models.Th08
             : base()
         {
             this.Score = score;
-            this.Name = Encoding.Default.GetBytes("--------\0");
-            this.Date = Encoding.Default.GetBytes("--/--\0");
+            this.Name = EncodingHelper.Default.GetBytes("--------\0");
+            this.Date = EncodingHelper.Default.GetBytes("--/--\0");
             this.CardFlags = ImmutableDictionary<int, byte>.Empty;
         }
 

--- a/ThScoreFileConverter/Models/Th08/ScoreReplacer.cs
+++ b/ThScoreFileConverter/Models/Th08/ScoreReplacer.cs
@@ -46,17 +46,17 @@ namespace ThScoreFileConverter.Models.Th08
                 switch (type)
                 {
                     case "1":   // name
-                        return Encoding.Default.GetString(score.Name.ToArray()).Split('\0')[0];
+                        return EncodingHelper.Default.GetString(score.Name.ToArray()).Split('\0')[0];
                     case "2":   // score
                         return formatter.FormatNumber((score.Score * 10) + score.ContinueCount);
                     case "3":   // stage
                         if ((level == Level.Extra) &&
-                            (Encoding.Default.GetString(score.Date.ToArray()).TrimEnd('\0') == "--/--"))
+                            (EncodingHelper.Default.GetString(score.Date.ToArray()).TrimEnd('\0') == "--/--"))
                             return StageProgress.Extra.ToShortName();
                         else
                             return score.StageProgress.ToShortName();
                     case "4":   // date
-                        return Encoding.Default.GetString(score.Date.ToArray()).TrimEnd('\0');
+                        return EncodingHelper.Default.GetString(score.Date.ToArray()).TrimEnd('\0');
                     case "5":   // slow rate
                         return formatter.FormatPercent(score.SlowRate, 3);
                     case "6":   // play time

--- a/ThScoreFileConverter/Models/Th08Converter.cs
+++ b/ThScoreFileConverter/Models/Th08Converter.cs
@@ -102,8 +102,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -123,7 +123,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
             var chapter = new Th06.Chapter();
 
@@ -181,7 +181,7 @@ namespace ThScoreFileConverter.Models
                 { Th07.VersionInfo.ValidSignature, (data, ch) => data.Set(new Th07.VersionInfo(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th06.Chapter();
 

--- a/ThScoreFileConverter/Models/Th08Converter.cs
+++ b/ThScoreFileConverter/Models/Th08Converter.cs
@@ -102,8 +102,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -123,7 +123,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var header = new FileHeader();
             var chapter = new Th06.Chapter();
 
@@ -181,7 +181,7 @@ namespace ThScoreFileConverter.Models
                 { Th07.VersionInfo.ValidSignature, (data, ch) => data.Set(new Th07.VersionInfo(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th06.Chapter();
 

--- a/ThScoreFileConverter/Models/Th09/ClearReplacer.cs
+++ b/ThScoreFileConverter/Models/Th09/ClearReplacer.cs
@@ -54,7 +54,7 @@ namespace ThScoreFileConverter.Models.Th09
                         var score = rankings.TryGetValue((chara, level), out var ranking) && (ranking.Count > 0)
                             ? ranking[0] : null;
                         var date = (score is not null)
-                            ? Encoding.Default.GetString(score.Date.ToArray()).TrimEnd('\0') : "--/--";
+                            ? EncodingHelper.Default.GetString(score.Date.ToArray()).TrimEnd('\0') : "--/--";
                         return (date != "--/--") ? "Not Cleared" : "-------";
                     }
                 }

--- a/ThScoreFileConverter/Models/Th09/ScoreReplacer.cs
+++ b/ThScoreFileConverter/Models/Th09/ScoreReplacer.cs
@@ -44,13 +44,13 @@ namespace ThScoreFileConverter.Models.Th09
                 {
                     case 1:     // name
                         return (score is not null)
-                            ? Encoding.Default.GetString(score.Name.ToArray()).Split('\0')[0] : "--------";
+                            ? EncodingHelper.Default.GetString(score.Name.ToArray()).Split('\0')[0] : "--------";
                     case 2:     // score
                         return formatter.FormatNumber(
                             (score is not null) ? ((score.Score * 10) + score.ContinueCount) : default);
                     case 3:     // date
                         date = (score is not null)
-                            ? Encoding.Default.GetString(score.Date.ToArray()).Split('\0')[0] : "--/--";
+                            ? EncodingHelper.Default.GetString(score.Date.ToArray()).Split('\0')[0] : "--/--";
                         return (date != "--/--") ? date : "--/--/--";
                     default:    // unreachable
                         return match.ToString();

--- a/ThScoreFileConverter/Models/Th095/BestShotHeader.cs
+++ b/ThScoreFileConverter/Models/Th095/BestShotHeader.cs
@@ -39,7 +39,7 @@ namespace ThScoreFileConverter.Models.Th095
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(SignatureSize));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(SignatureSize));
             if (!this.Signature.Equals(ValidSignature, StringComparison.Ordinal))
                 throw new InvalidDataException();
 

--- a/ThScoreFileConverter/Models/Th095/Chapter.cs
+++ b/ThScoreFileConverter/Models/Th095/Chapter.cs
@@ -11,6 +11,7 @@ using System;
 using System.IO;
 using System.Linq;
 using ThScoreFileConverter.Extensions;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Properties;
 
 namespace ThScoreFileConverter.Models.Th095
@@ -72,7 +73,7 @@ namespace ThScoreFileConverter.Models.Th095
         {
             get
             {
-                var sigVer = Encoding.Default.GetBytes(this.Signature)
+                var sigVer = EncodingHelper.Default.GetBytes(this.Signature)
                     .Concat(BitConverter.GetBytes(this.Version))
                     .ToArray();
                 if (sigVer.Length < sizeof(uint))
@@ -90,7 +91,7 @@ namespace ThScoreFileConverter.Models.Th095
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(SignatureSize));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(SignatureSize));
             this.Version = reader.ReadUInt16();
             this.Size = reader.ReadInt32();
             this.Checksum = reader.ReadUInt32();

--- a/ThScoreFileConverter/Models/Th095/HeaderBase.cs
+++ b/ThScoreFileConverter/Models/Th095/HeaderBase.cs
@@ -9,6 +9,7 @@
 
 using System.IO;
 using ThScoreFileConverter.Extensions;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Properties;
 
 namespace ThScoreFileConverter.Models.Th095
@@ -41,7 +42,7 @@ namespace ThScoreFileConverter.Models.Th095
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(SignatureSize));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(SignatureSize));
 
             this.EncodedAllSize = reader.ReadInt32();
             if (this.EncodedAllSize < 0)
@@ -70,7 +71,7 @@ namespace ThScoreFileConverter.Models.Th095
 
         public void WriteTo(BinaryWriter writer)
         {
-            writer.Write(Encoding.Default.GetBytes(this.Signature));
+            writer.Write(EncodingHelper.Default.GetBytes(this.Signature));
             writer.Write(this.EncodedAllSize);
             writer.Write(this.unknown1);
             writer.Write(this.unknown2);

--- a/ThScoreFileConverter/Models/Th095/ShotReplacer.cs
+++ b/ThScoreFileConverter/Models/Th095/ShotReplacer.cs
@@ -46,7 +46,7 @@ namespace ThScoreFileConverter.Models.Th095
                         "ClearData: {0}{3}Slow: {1}{3}SpellName: {2}",
                         formatter.FormatNumber(bestshot.Header.ResultScore),
                         formatter.FormatPercent(bestshot.Header.SlowRate, 6),
-                        Encoding.Default.GetString(bestshot.Header.CardName.ToArray()).TrimEnd('\0'),
+                        EncodingHelper.Default.GetString(bestshot.Header.CardName.ToArray()).TrimEnd('\0'),
                         Environment.NewLine);
                     return Utils.Format(
                         "<img src=\"{0}\" alt=\"{1}\" title=\"{1}\" border=0>", relativePath, alternativeString);

--- a/ThScoreFileConverter/Models/Th095Converter.cs
+++ b/ThScoreFileConverter/Models/Th095Converter.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using ThScoreFileConverter.Extensions;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Models.Th095;
 using ThScoreFileConverter.Properties;
 
@@ -102,8 +103,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -120,8 +121,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -137,7 +138,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -173,7 +174,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature, (data, ch) => data.Set(new Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Chapter();
 

--- a/ThScoreFileConverter/Models/Th095Converter.cs
+++ b/ThScoreFileConverter/Models/Th095Converter.cs
@@ -103,8 +103,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -121,8 +121,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -138,7 +138,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -174,7 +174,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature, (data, ch) => data.Set(new Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Chapter();
 

--- a/ThScoreFileConverter/Models/Th09Converter.cs
+++ b/ThScoreFileConverter/Models/Th09Converter.cs
@@ -99,8 +99,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -120,7 +120,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var header = new FileHeader();
             var chapter = new Th06.Chapter();
 
@@ -169,7 +169,7 @@ namespace ThScoreFileConverter.Models
                 { Th07.VersionInfo.ValidSignature, (data, ch) => data.Set(new Th07.VersionInfo(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th06.Chapter();
 

--- a/ThScoreFileConverter/Models/Th09Converter.cs
+++ b/ThScoreFileConverter/Models/Th09Converter.cs
@@ -99,8 +99,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
 
             header.ReadFrom(reader);
@@ -120,7 +120,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var header = new FileHeader();
             var chapter = new Th06.Chapter();
 
@@ -169,7 +169,7 @@ namespace ThScoreFileConverter.Models
                 { Th07.VersionInfo.ValidSignature, (data, ch) => data.Set(new Th07.VersionInfo(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th06.Chapter();
 

--- a/ThScoreFileConverter/Models/Th10/Chapter.cs
+++ b/ThScoreFileConverter/Models/Th10/Chapter.cs
@@ -11,6 +11,7 @@ using System;
 using System.IO;
 using System.Linq;
 using ThScoreFileConverter.Extensions;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Properties;
 
 namespace ThScoreFileConverter.Models.Th10
@@ -81,7 +82,7 @@ namespace ThScoreFileConverter.Models.Th10
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(SignatureSize));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(SignatureSize));
             this.Version = reader.ReadUInt16();
             this.Checksum = reader.ReadUInt32();
             this.Size = reader.ReadInt32();

--- a/ThScoreFileConverter/Models/Th10/ScoreReplacerBase.cs
+++ b/ThScoreFileConverter/Models/Th10/ScoreReplacerBase.cs
@@ -43,7 +43,7 @@ namespace ThScoreFileConverter.Models.Th10
                 {
                     case 1:     // name
                         return score.Name.Any()
-                            ? Encoding.Default.GetString(score.Name.ToArray()).Split('\0')[0] : "--------";
+                            ? EncodingHelper.Default.GetString(score.Name.ToArray()).Split('\0')[0] : "--------";
                     case 2:     // score
                         return formatter.FormatNumber((score.Score * 10) + score.ContinueCount);
                     case 3:     // stage

--- a/ThScoreFileConverter/Models/Th105Converter.cs
+++ b/ThScoreFileConverter/Models/Th105Converter.cs
@@ -103,7 +103,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th105Converter.cs
+++ b/ThScoreFileConverter/Models/Th105Converter.cs
@@ -103,7 +103,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th10Converter.cs
+++ b/ThScoreFileConverter/Models/Th10Converter.cs
@@ -76,8 +76,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -94,8 +94,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -111,7 +111,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -147,7 +147,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Chapter();
 

--- a/ThScoreFileConverter/Models/Th10Converter.cs
+++ b/ThScoreFileConverter/Models/Th10Converter.cs
@@ -76,8 +76,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -94,8 +94,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -111,7 +111,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -147,7 +147,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Chapter();
 

--- a/ThScoreFileConverter/Models/Th11Converter.cs
+++ b/ThScoreFileConverter/Models/Th11Converter.cs
@@ -76,8 +76,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -94,8 +94,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -111,7 +111,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -147,7 +147,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th11Converter.cs
+++ b/ThScoreFileConverter/Models/Th11Converter.cs
@@ -76,8 +76,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -94,8 +94,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -111,7 +111,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -147,7 +147,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th123Converter.cs
+++ b/ThScoreFileConverter/Models/Th123Converter.cs
@@ -104,7 +104,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th123Converter.cs
+++ b/ThScoreFileConverter/Models/Th123Converter.cs
@@ -104,7 +104,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th125/BestShotHeader.cs
+++ b/ThScoreFileConverter/Models/Th125/BestShotHeader.cs
@@ -71,7 +71,7 @@ namespace ThScoreFileConverter.Models.Th125
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(SignatureSize));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(SignatureSize));
             if (!this.Signature.Equals(ValidSignature, StringComparison.Ordinal))
                 throw new InvalidDataException();
 

--- a/ThScoreFileConverter/Models/Th125/ShotReplacer.cs
+++ b/ThScoreFileConverter/Models/Th125/ShotReplacer.cs
@@ -49,7 +49,7 @@ namespace ThScoreFileConverter.Models.Th125
                         "ClearData: {0}{3}Slow: {1}{3}SpellName: {2}",
                         formatter.FormatNumber(bestshot.Header.ResultScore),
                         formatter.FormatPercent(bestshot.Header.SlowRate, 6),
-                        Encoding.Default.GetString(bestshot.Header.CardName.ToArray()).TrimEnd('\0'),
+                        EncodingHelper.Default.GetString(bestshot.Header.CardName.ToArray()).TrimEnd('\0'),
                         Environment.NewLine);
                     return Utils.Format(
                         "<img src=\"{0}\" alt=\"{1}\" title=\"{1}\" border=0>", relativePath, alternativeString);

--- a/ThScoreFileConverter/Models/Th125Converter.cs
+++ b/ThScoreFileConverter/Models/Th125Converter.cs
@@ -107,8 +107,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -125,8 +125,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -142,7 +142,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -178,7 +178,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature, (data, ch) => data.Set(new Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th095.Chapter();
 

--- a/ThScoreFileConverter/Models/Th125Converter.cs
+++ b/ThScoreFileConverter/Models/Th125Converter.cs
@@ -107,8 +107,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -125,8 +125,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -142,7 +142,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -178,7 +178,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature, (data, ch) => data.Set(new Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th095.Chapter();
 

--- a/ThScoreFileConverter/Models/Th128/ScoreReplacer.cs
+++ b/ThScoreFileConverter/Models/Th128/ScoreReplacer.cs
@@ -49,7 +49,7 @@ namespace ThScoreFileConverter.Models.Th128
                 {
                     case 1:     // name
                         return ranking.Name.Any()
-                            ? Encoding.Default.GetString(ranking.Name.ToArray()).Split('\0')[0] : "--------";
+                            ? EncodingHelper.Default.GetString(ranking.Name.ToArray()).Split('\0')[0] : "--------";
                     case 2:     // score
                         return formatter.FormatNumber((ranking.Score * 10) + ranking.ContinueCount);
                     case 3:     // stage

--- a/ThScoreFileConverter/Models/Th128Converter.cs
+++ b/ThScoreFileConverter/Models/Th128Converter.cs
@@ -77,8 +77,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -95,8 +95,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -112,7 +112,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -151,7 +151,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th128Converter.cs
+++ b/ThScoreFileConverter/Models/Th128Converter.cs
@@ -77,8 +77,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -95,8 +95,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -112,7 +112,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -151,7 +151,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th12Converter.cs
+++ b/ThScoreFileConverter/Models/Th12Converter.cs
@@ -76,8 +76,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -94,8 +94,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -111,7 +111,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -147,7 +147,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th12Converter.cs
+++ b/ThScoreFileConverter/Models/Th12Converter.cs
@@ -76,8 +76,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -94,8 +94,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -111,7 +111,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -147,7 +147,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th13/ScoreReplacerBase.cs
+++ b/ThScoreFileConverter/Models/Th13/ScoreReplacerBase.cs
@@ -43,7 +43,7 @@ namespace ThScoreFileConverter.Models.Th13
                 {
                     case 1:     // name
                         return score.Name.Any()
-                            ? Encoding.Default.GetString(score.Name.ToArray()).Split('\0')[0] : "--------";
+                            ? EncodingHelper.Default.GetString(score.Name.ToArray()).Split('\0')[0] : "--------";
                     case 2:     // score
                         return formatter.FormatNumber((score.Score * 10) + score.ContinueCount);
                     case 3:     // stage

--- a/ThScoreFileConverter/Models/Th135Converter.cs
+++ b/ThScoreFileConverter/Models/Th135Converter.cs
@@ -104,7 +104,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th135Converter.cs
+++ b/ThScoreFileConverter/Models/Th135Converter.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Models.Th135;
 using ThScoreFileConverter.Properties;
 
@@ -103,7 +104,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th13Converter.cs
+++ b/ThScoreFileConverter/Models/Th13Converter.cs
@@ -83,8 +83,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -101,8 +101,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -118,7 +118,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -154,7 +154,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th13Converter.cs
+++ b/ThScoreFileConverter/Models/Th13Converter.cs
@@ -83,8 +83,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -101,8 +101,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -118,7 +118,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -154,7 +154,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th143/BestShotHeader.cs
+++ b/ThScoreFileConverter/Models/Th143/BestShotHeader.cs
@@ -35,7 +35,7 @@ namespace ThScoreFileConverter.Models.Th143
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(SignatureSize));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(SignatureSize));
             if (!this.Signature.Equals(ValidSignature, StringComparison.Ordinal))
                 throw new InvalidDataException();
 

--- a/ThScoreFileConverter/Models/Th143Converter.cs
+++ b/ThScoreFileConverter/Models/Th143Converter.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using ThScoreFileConverter.Extensions;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Models.Th143;
 using ThScoreFileConverter.Properties;
 
@@ -103,8 +104,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -121,8 +122,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -138,7 +139,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -177,7 +178,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,     (data, ch) => data.Set(new Status(ch))     },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th143Converter.cs
+++ b/ThScoreFileConverter/Models/Th143Converter.cs
@@ -104,8 +104,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -122,8 +122,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -139,7 +139,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -178,7 +178,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,     (data, ch) => data.Set(new Status(ch))     },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th145Converter.cs
+++ b/ThScoreFileConverter/Models/Th145Converter.cs
@@ -105,7 +105,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th145Converter.cs
+++ b/ThScoreFileConverter/Models/Th145Converter.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Models.Th145;
 using ThScoreFileConverter.Properties;
 
@@ -104,7 +105,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th14Converter.cs
+++ b/ThScoreFileConverter/Models/Th14Converter.cs
@@ -83,8 +83,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -101,8 +101,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -118,7 +118,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -154,7 +154,7 @@ namespace ThScoreFileConverter.Models
                 { Th13.Status.ValidSignature, (data, ch) => data.Set(new Th13.Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th14Converter.cs
+++ b/ThScoreFileConverter/Models/Th14Converter.cs
@@ -83,8 +83,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -101,8 +101,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -118,7 +118,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -154,7 +154,7 @@ namespace ThScoreFileConverter.Models
                 { Th13.Status.ValidSignature, (data, ch) => data.Set(new Th13.Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th15/ScoreReplacer.cs
+++ b/ThScoreFileConverter/Models/Th15/ScoreReplacer.cs
@@ -52,7 +52,7 @@ namespace ThScoreFileConverter.Models.Th15
                 {
                     case 1:     // name
                         return ranking.Name.Any()
-                            ? Encoding.Default.GetString(ranking.Name.ToArray()).Split('\0')[0] : "--------";
+                            ? EncodingHelper.Default.GetString(ranking.Name.ToArray()).Split('\0')[0] : "--------";
                     case 2:     // score
                         return formatter.FormatNumber((ranking.Score * 10) + ranking.ContinueCount);
                     case 3:     // stage

--- a/ThScoreFileConverter/Models/Th155Converter.cs
+++ b/ThScoreFileConverter/Models/Th155Converter.cs
@@ -104,7 +104,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th155Converter.cs
+++ b/ThScoreFileConverter/Models/Th155Converter.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Models.Th155;
 using ThScoreFileConverter.Properties;
 
@@ -103,7 +104,7 @@ namespace ThScoreFileConverter.Models
 
         private static AllScoreData? Read(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
 
             try

--- a/ThScoreFileConverter/Models/Th15Converter.cs
+++ b/ThScoreFileConverter/Models/Th15Converter.cs
@@ -75,8 +75,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -93,8 +93,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -110,7 +110,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -146,7 +146,7 @@ namespace ThScoreFileConverter.Models
                 { Th13.Status.ValidSignature, (data, ch) => data.Set(new Th13.Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th15Converter.cs
+++ b/ThScoreFileConverter/Models/Th15Converter.cs
@@ -75,8 +75,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -93,8 +93,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -110,7 +110,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -146,7 +146,7 @@ namespace ThScoreFileConverter.Models
                 { Th13.Status.ValidSignature, (data, ch) => data.Set(new Th13.Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th16/ScoreReplacer.cs
+++ b/ThScoreFileConverter/Models/Th16/ScoreReplacer.cs
@@ -51,7 +51,7 @@ namespace ThScoreFileConverter.Models.Th16
                 {
                     case 1:     // name
                         return ranking.Name.Any()
-                            ? Encoding.Default.GetString(ranking.Name.ToArray()).Split('\0')[0] : "--------";
+                            ? EncodingHelper.Default.GetString(ranking.Name.ToArray()).Split('\0')[0] : "--------";
                     case 2:     // score
                         return formatter.FormatNumber((ranking.Score * 10) + ranking.ContinueCount);
                     case 3:     // stage

--- a/ThScoreFileConverter/Models/Th165/BestShotHeader.cs
+++ b/ThScoreFileConverter/Models/Th165/BestShotHeader.cs
@@ -93,7 +93,7 @@ namespace ThScoreFileConverter.Models.Th165
 
         public void ReadFrom(BinaryReader reader)
         {
-            this.Signature = Encoding.Default.GetString(reader.ReadExactBytes(SignatureSize));
+            this.Signature = EncodingHelper.Default.GetString(reader.ReadExactBytes(SignatureSize));
             if (!this.Signature.Equals(ValidSignature, StringComparison.Ordinal))
                 throw new InvalidDataException();
 

--- a/ThScoreFileConverter/Models/Th165Converter.cs
+++ b/ThScoreFileConverter/Models/Th165Converter.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using ThScoreFileConverter.Extensions;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Models.Th165;
 using ThScoreFileConverter.Properties;
 
@@ -103,8 +104,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -121,8 +122,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -138,7 +139,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -175,7 +176,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature, (data, ch) => data.Set(new Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th165Converter.cs
+++ b/ThScoreFileConverter/Models/Th165Converter.cs
@@ -104,8 +104,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -122,8 +122,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -139,7 +139,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -176,7 +176,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature, (data, ch) => data.Set(new Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th16Converter.cs
+++ b/ThScoreFileConverter/Models/Th16Converter.cs
@@ -83,8 +83,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -101,8 +101,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -118,7 +118,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -154,7 +154,7 @@ namespace ThScoreFileConverter.Models
                 { Th13.Status.ValidSignature, (data, ch) => data.Set(new Th13.Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th16Converter.cs
+++ b/ThScoreFileConverter/Models/Th16Converter.cs
@@ -83,8 +83,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -101,8 +101,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -118,7 +118,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -154,7 +154,7 @@ namespace ThScoreFileConverter.Models
                 { Th13.Status.ValidSignature, (data, ch) => data.Set(new Th13.Status(ch)) },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th17Converter.cs
+++ b/ThScoreFileConverter/Models/Th17Converter.cs
@@ -84,8 +84,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -102,8 +102,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -119,7 +119,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -155,7 +155,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th17Converter.cs
+++ b/ThScoreFileConverter/Models/Th17Converter.cs
@@ -84,8 +84,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -102,8 +102,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -119,7 +119,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -155,7 +155,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th18Converter.cs
+++ b/ThScoreFileConverter/Models/Th18Converter.cs
@@ -77,8 +77,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -95,8 +95,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
-            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -112,7 +112,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -148,7 +148,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8NoBOM, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/Th18Converter.cs
+++ b/ThScoreFileConverter/Models/Th18Converter.cs
@@ -77,8 +77,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Decrypt(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
             var header = new Header();
 
             header.ReadFrom(reader);
@@ -95,8 +95,8 @@ namespace ThScoreFileConverter.Models
 
         private static bool Extract(Stream input, Stream output)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
-            using var writer = new BinaryWriter(output, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
+            using var writer = new BinaryWriter(output, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -112,7 +112,7 @@ namespace ThScoreFileConverter.Models
 
         private static bool Validate(Stream input)
         {
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
 
             var header = new Header();
             header.ReadFrom(reader);
@@ -148,7 +148,7 @@ namespace ThScoreFileConverter.Models
                 { Status.ValidSignature,    (data, ch) => data.Set(new Status(ch))    },
             };
 
-            using var reader = new BinaryReader(input, Encoding.UTF8, true);
+            using var reader = new BinaryReader(input, EncodingHelper.UTF8, true);
             var allScoreData = new AllScoreData();
             var chapter = new Th10.Chapter();
 

--- a/ThScoreFileConverter/Models/ThConverter.cs
+++ b/ThScoreFileConverter/Models/ThConverter.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Properties;
 
 namespace ThScoreFileConverter.Models
@@ -230,8 +231,8 @@ namespace ThScoreFileConverter.Models
             }
 
             const int DefaultBufferSize = 1024;
-            var inputEncoding = Encoding.GetEncoding(inputCodePageId);
-            var outputEncoding = Encoding.GetEncoding(outputCodePageId);
+            var inputEncoding = EncodingHelper.GetEncoding(inputCodePageId);
+            var outputEncoding = EncodingHelper.GetEncoding(outputCodePageId);
             var numFiles = settings.TemplateFiles.Count();
             for (var index = 0; index < numFiles; index++)
             {

--- a/ThScoreFileConverter/Squirrel/SQString.cs
+++ b/ThScoreFileConverter/Squirrel/SQString.cs
@@ -10,7 +10,7 @@
 using System;
 using System.IO;
 using ThScoreFileConverter.Extensions;
-using ThScoreFileConverter.Models;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Properties;
 
 namespace ThScoreFileConverter.Squirrel
@@ -45,7 +45,7 @@ namespace ThScoreFileConverter.Squirrel
 
             var size = reader.ReadInt32();
             return new SQString(
-                (size > 0) ? Encoding.CP932.GetString(reader.ReadExactBytes(size)) : string.Empty);
+                (size > 0) ? EncodingHelper.CP932.GetString(reader.ReadExactBytes(size)) : string.Empty);
         }
 
         public override bool Equals(object? obj)

--- a/ThScoreFileConverter/ViewModels/SettingWindowViewModel.cs
+++ b/ThScoreFileConverter/ViewModels/SettingWindowViewModel.cs
@@ -17,6 +17,7 @@ using Prism.Services.Dialogs;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 using ThScoreFileConverter.Adapters;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverter.Interactivity;
 using ThScoreFileConverter.Models;
 using ThScoreFileConverter.Properties;
@@ -70,7 +71,7 @@ namespace ThScoreFileConverter.ViewModels
                 x => x.OutputCodePageId, value => (int)value!, value => value);
 
             var encodings = Settings.ValidCodePageIds
-                .ToDictionary(id => id, id => Encoding.GetEncoding(id).EncodingName);
+                .ToDictionary(id => id, id => EncodingHelper.GetEncoding(id).EncodingName);
             this.InputEncodings = encodings;
             this.OutputEncodings = encodings;
 

--- a/ThScoreFileConverterTests/Helpers/EncodingHelperTests.cs
+++ b/ThScoreFileConverterTests/Helpers/EncodingHelperTests.cs
@@ -22,8 +22,8 @@ namespace ThScoreFileConverterTests.Helpers
         [TestMethod]
         public void UTF8Test()
         {
-            Assert.AreNotEqual(System.Text.Encoding.UTF8, EncodingHelper.UTF8);
-            Assert.AreEqual(new System.Text.UTF8Encoding(false), EncodingHelper.UTF8);
+            Assert.AreNotEqual(System.Text.Encoding.UTF8, EncodingHelper.UTF8NoBOM);
+            Assert.AreEqual(new System.Text.UTF8Encoding(false), EncodingHelper.UTF8NoBOM);
         }
 
         [TestMethod]
@@ -33,7 +33,7 @@ namespace ThScoreFileConverterTests.Helpers
             Assert.AreNotEqual(System.Text.Encoding.GetEncoding(65001), utf8);
             Assert.AreNotEqual(System.Text.Encoding.UTF8, utf8);
             Assert.AreEqual(new System.Text.UTF8Encoding(false), utf8);
-            Assert.AreEqual(EncodingHelper.UTF8, utf8);
+            Assert.AreEqual(EncodingHelper.UTF8NoBOM, utf8);
         }
 
         [TestMethod]

--- a/ThScoreFileConverterTests/Helpers/EncodingHelperTests.cs
+++ b/ThScoreFileConverterTests/Helpers/EncodingHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ThScoreFileConverter.Helpers;
 using ThScoreFileConverterTests.UnitTesting;
 
@@ -16,23 +17,30 @@ namespace ThScoreFileConverterTests.Helpers
         [TestMethod]
         public void DefaultTest()
         {
-            Assert.AreEqual(System.Text.Encoding.Default, EncodingHelper.Default);
+            Assert.AreEqual(Encoding.Default, EncodingHelper.Default);
         }
 
         [TestMethod]
         public void UTF8Test()
         {
-            Assert.AreNotEqual(System.Text.Encoding.UTF8, EncodingHelper.UTF8NoBOM);
-            Assert.AreEqual(new System.Text.UTF8Encoding(false), EncodingHelper.UTF8NoBOM);
+            Assert.AreEqual(Encoding.UTF8, EncodingHelper.UTF8);
+            Assert.AreNotEqual(new UTF8Encoding(false), EncodingHelper.UTF8);
+        }
+
+        [TestMethod]
+        public void UTF8NoBOMTest()
+        {
+            Assert.AreNotEqual(Encoding.UTF8, EncodingHelper.UTF8NoBOM);
+            Assert.AreEqual(new UTF8Encoding(false), EncodingHelper.UTF8NoBOM);
         }
 
         [TestMethod]
         public void GetEncodingTestUTF8()
         {
             var utf8 = EncodingHelper.GetEncoding(65001);
-            Assert.AreNotEqual(System.Text.Encoding.GetEncoding(65001), utf8);
-            Assert.AreNotEqual(System.Text.Encoding.UTF8, utf8);
-            Assert.AreEqual(new System.Text.UTF8Encoding(false), utf8);
+            Assert.AreNotEqual(Encoding.GetEncoding(65001), utf8);
+            Assert.AreNotEqual(Encoding.UTF8, utf8);
+            Assert.AreEqual(new UTF8Encoding(false), utf8);
             Assert.AreEqual(EncodingHelper.UTF8NoBOM, utf8);
         }
 
@@ -40,11 +48,11 @@ namespace ThScoreFileConverterTests.Helpers
         public void GetEncodingTestNotUTF8Twice()
         {
             var cp932 = EncodingHelper.GetEncoding(932);
-            Assert.AreEqual(System.Text.Encoding.GetEncoding(932), cp932);
+            Assert.AreEqual(Encoding.GetEncoding(932), cp932);
             Assert.AreEqual(EncodingHelper.CP932, cp932);
 
             cp932 = EncodingHelper.GetEncoding(932);
-            Assert.AreEqual(System.Text.Encoding.GetEncoding(932), cp932);
+            Assert.AreEqual(Encoding.GetEncoding(932), cp932);
             Assert.AreEqual(EncodingHelper.CP932, cp932);
         }
     }

--- a/ThScoreFileConverterTests/Helpers/EncodingHelperTests.cs
+++ b/ThScoreFileConverterTests/Helpers/EncodingHelperTests.cs
@@ -1,51 +1,51 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ThScoreFileConverter.Models;
+using ThScoreFileConverter.Helpers;
 using ThScoreFileConverterTests.UnitTesting;
 
-namespace ThScoreFileConverterTests.Models
+namespace ThScoreFileConverterTests.Helpers
 {
     [TestClass]
-    public class EncodingTests
+    public class EncodingHelperTests
     {
         [TestMethod]
         public void CP932Test()
         {
-            Assert.AreEqual(TestUtils.CP932Encoding, Encoding.CP932);
+            Assert.AreEqual(TestUtils.CP932Encoding, EncodingHelper.CP932);
         }
 
         [TestMethod]
         public void DefaultTest()
         {
-            Assert.AreEqual(System.Text.Encoding.Default, Encoding.Default);
+            Assert.AreEqual(System.Text.Encoding.Default, EncodingHelper.Default);
         }
 
         [TestMethod]
         public void UTF8Test()
         {
-            Assert.AreNotEqual(System.Text.Encoding.UTF8, Encoding.UTF8);
-            Assert.AreEqual(new System.Text.UTF8Encoding(false), Encoding.UTF8);
+            Assert.AreNotEqual(System.Text.Encoding.UTF8, EncodingHelper.UTF8);
+            Assert.AreEqual(new System.Text.UTF8Encoding(false), EncodingHelper.UTF8);
         }
 
         [TestMethod]
         public void GetEncodingTestUTF8()
         {
-            var utf8 = Encoding.GetEncoding(65001);
+            var utf8 = EncodingHelper.GetEncoding(65001);
             Assert.AreNotEqual(System.Text.Encoding.GetEncoding(65001), utf8);
             Assert.AreNotEqual(System.Text.Encoding.UTF8, utf8);
             Assert.AreEqual(new System.Text.UTF8Encoding(false), utf8);
-            Assert.AreEqual(Encoding.UTF8, utf8);
+            Assert.AreEqual(EncodingHelper.UTF8, utf8);
         }
 
         [TestMethod]
         public void GetEncodingTestNotUTF8Twice()
         {
-            var cp932 = Encoding.GetEncoding(932);
+            var cp932 = EncodingHelper.GetEncoding(932);
             Assert.AreEqual(System.Text.Encoding.GetEncoding(932), cp932);
-            Assert.AreEqual(Encoding.CP932, cp932);
+            Assert.AreEqual(EncodingHelper.CP932, cp932);
 
-            cp932 = Encoding.GetEncoding(932);
+            cp932 = EncodingHelper.GetEncoding(932);
             Assert.AreEqual(System.Text.Encoding.GetEncoding(932), cp932);
-            Assert.AreEqual(Encoding.CP932, cp932);
+            Assert.AreEqual(EncodingHelper.CP932, cp932);
         }
     }
 }


### PR DESCRIPTION
There are two classes with the same name, `Encoding`, and each has the property with the same name, `UTF8`:
* `System.Text.Encoding.UTF8`
* `ThScoreFileConverter.Models.Encoding.UTF8`

However, despite having the same name, there is a difference that the former emits the UTF-8 byte order marker and the latter does not. It is so easy to lead misunderstanding, especially if one of them is referenced in the form `Encoding.UTF8`.

This PR removes such confusing situation by renaming the latter as `ThScoreFileConverter.Helpers.EncodingHelper.UTF8NoBOM`.