### PR TITLE
Make the main window resizable

### DIFF
--- a/ThScoreFileConverter.Tests/SettingsTests.cs
+++ b/ThScoreFileConverter.Tests/SettingsTests.cs
@@ -63,6 +63,27 @@ namespace ThScoreFileConverter.Tests;
 [DeploymentItem(@"TestData\empty-language.xml", @"TestData")]
 [DeploymentItem(@"TestData\invalid-language.xml", @"TestData")]
 [DeploymentItem(@"TestData\valid-language-ja-JP.xml", @"TestData")]
+[DeploymentItem(@"TestData\no-optional-settings.xml", @"TestData")]
+[DeploymentItem(@"TestData\empty-window-width.xml", @"TestData")]
+[DeploymentItem(@"TestData\invalid-window-width.xml", @"TestData")]
+[DeploymentItem(@"TestData\negative-window-width.xml", @"TestData")]
+[DeploymentItem(@"TestData\zero-window-width.xml", @"TestData")]
+[DeploymentItem(@"TestData\below-window-width.xml", @"TestData")]
+[DeploymentItem(@"TestData\empty-window-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\invalid-window-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\negative-window-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\zero-window-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\below-window-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\empty-main-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\invalid-main-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\negative-main-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\zero-main-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\below-main-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\empty-sub-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\invalid-sub-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\negative-sub-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\zero-sub-content-height.xml", @"TestData")]
+[DeploymentItem(@"TestData\below-sub-content-height.xml", @"TestData")]
 [DeploymentItem(@"TestData\invalid-character.xml", @"TestData")]
 #endif
 public class SettingsTests
@@ -79,6 +100,10 @@ public class SettingsTests
         Assert.AreEqual(65001, settings.InputCodePageId);
         Assert.AreEqual(65001, settings.OutputCodePageId);
         Assert.AreEqual(CultureInfo.InvariantCulture.Name, settings.Language);
+        Assert.AreEqual(Settings.WindowMinWidth, settings.WindowWidth);
+        Assert.AreEqual(Settings.WindowMinHeight, settings.WindowHeight);
+        Assert.AreEqual(Settings.MainContentMinHeight, settings.MainContentHeight);
+        Assert.AreEqual(Settings.SubContentMinHeight, settings.SubContentHeight);
     }
 
     [TestMethod]
@@ -106,6 +131,10 @@ public class SettingsTests
         Assert.AreEqual(65001, settings.InputCodePageId);
         Assert.AreEqual(65001, settings.OutputCodePageId);
         Assert.AreEqual(CultureInfo.InvariantCulture.Name, settings.Language);
+        Assert.AreEqual(Settings.WindowMinWidth, settings.WindowWidth);
+        Assert.AreEqual(Settings.WindowMinHeight, settings.WindowHeight);
+        Assert.AreEqual(Settings.MainContentMinHeight, settings.MainContentHeight);
+        Assert.AreEqual(Settings.SubContentMinHeight, settings.SubContentHeight);
     }
 
     [TestMethod]
@@ -530,6 +559,190 @@ public class SettingsTests
     }
 
     [TestMethod]
+    public void LoadTestNoWindowWidth()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\no-optional-settings.xml");
+        Assert.AreEqual(Settings.WindowMinWidth, settings.WindowWidth);
+    }
+
+    [TestMethod]
+    public void LoadTestEmptyWindowWidth()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\empty-window-width.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestInvalidWindowWidth()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\invalid-window-width.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestNegativeWindowWidth()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\negative-window-width.xml");
+        Assert.AreEqual(Settings.WindowMinWidth, settings.WindowWidth);
+    }
+
+    [TestMethod]
+    public void LoadTestZeroWindowWidth()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\zero-window-width.xml");
+        Assert.AreEqual(Settings.WindowMinWidth, settings.WindowWidth);
+    }
+
+    [TestMethod]
+    public void LoadTestBelowWindowWidth()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\below-window-width.xml");
+        Assert.AreEqual(Settings.WindowMinWidth, settings.WindowWidth);
+    }
+
+    [TestMethod]
+    public void LoadTestNoWindowHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\no-optional-settings.xml");
+        Assert.AreEqual(Settings.WindowMinHeight, settings.WindowHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestEmptyWindowHeight()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\empty-window-height.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestInvalidWindowHeight()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\invalid-window-height.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestNegativeWindowHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\negative-window-height.xml");
+        Assert.AreEqual(Settings.WindowMinHeight, settings.WindowHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestZeroWindowHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\zero-window-height.xml");
+        Assert.AreEqual(Settings.WindowMinHeight, settings.WindowHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestBelowWindowHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\below-window-height.xml");
+        Assert.AreEqual(Settings.WindowMinHeight, settings.WindowHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestNoMainContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\no-optional-settings.xml");
+        Assert.AreEqual(Settings.MainContentMinHeight, settings.MainContentHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestEmptyMainContentHeight()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\empty-main-content-height.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestInvalidMainContentHeight()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\invalid-main-content-height.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestNegativeMainContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\negative-main-content-height.xml");
+        Assert.AreEqual(Settings.MainContentMinHeight, settings.MainContentHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestZeroMainContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\zero-main-content-height.xml");
+        Assert.AreEqual(Settings.MainContentMinHeight, settings.MainContentHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestBelowMainContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\below-main-content-height.xml");
+        Assert.AreEqual(Settings.MainContentMinHeight, settings.MainContentHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestNoSubContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\no-optional-settings.xml");
+        Assert.AreEqual(Settings.SubContentMinHeight, settings.SubContentHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestEmptySubContentHeight()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\empty-sub-content-height.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestInvalidSubContentHeight()
+    {
+        _ = Assert.ThrowsException<InvalidDataException>(
+            () => new Settings().Load(@"TestData\invalid-sub-content-height.xml"));
+    }
+
+    [TestMethod]
+    public void LoadTestNegativeSubContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\negative-sub-content-height.xml");
+        Assert.AreEqual(Settings.SubContentMinHeight, settings.SubContentHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestZeroSubContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\zero-sub-content-height.xml");
+        Assert.AreEqual(Settings.SubContentMinHeight, settings.SubContentHeight);
+    }
+
+    [TestMethod]
+    public void LoadTestBelowSubContentHeight()
+    {
+        var settings = new Settings();
+        settings.Load(@"TestData\below-sub-content-height.xml");
+        Assert.AreEqual(Settings.SubContentMinHeight, settings.SubContentHeight);
+    }
+
+    [TestMethod]
     public void LoadTestInvalidCharacter()
     {
         _ = Assert.ThrowsException<InvalidDataException>(
@@ -547,6 +760,11 @@ public class SettingsTests
             OutputNumberGroupSeparator = false,
             InputCodePageId = 932,
             OutputCodePageId = 932,
+            Language = "ja-JP",
+            WindowWidth = 480.5,
+            WindowHeight = 480.5,
+            MainContentHeight = 240.5,
+            SubContentHeight = 80.5,
         };
 
         var settingsPerTitle = settings.GetSettingsPerTitle(settings.LastTitle);
@@ -581,6 +799,12 @@ public class SettingsTests
         Assert.AreEqual(settings.OutputNumberGroupSeparator, settings2.OutputNumberGroupSeparator);
         Assert.AreEqual(settings.InputCodePageId, settings2.InputCodePageId);
         Assert.AreEqual(settings.OutputCodePageId, settings2.OutputCodePageId);
+        Assert.AreEqual(settings.Language, settings2.Language);
+
+        Assert.AreEqual(settings.WindowWidth, settings2.WindowWidth);
+        Assert.AreEqual(settings.WindowHeight, settings2.WindowHeight);
+        Assert.AreEqual(settings.MainContentHeight, settings2.MainContentHeight);
+        Assert.AreEqual(settings.SubContentHeight, settings2.SubContentHeight);
     }
 
     [TestMethod]
@@ -632,6 +856,30 @@ public class SettingsTests
         var language = settings.Language;
         settings.Language = "invalid";
         Assert.AreEqual(language, settings.Language);
+    }
+
+    [TestMethod]
+    public void WindowWidthTestNull()
+    {
+        _ = Assert.ThrowsException<ArgumentNullException>(() => new Settings().WindowWidth = null);
+    }
+
+    [TestMethod]
+    public void WindowHeightTestNull()
+    {
+        _ = Assert.ThrowsException<ArgumentNullException>(() => new Settings().WindowHeight = null);
+    }
+
+    [TestMethod]
+    public void MainContentHeightTestNull()
+    {
+        _ = Assert.ThrowsException<ArgumentNullException>(() => new Settings().MainContentHeight = null);
+    }
+
+    [TestMethod]
+    public void SubContentHeightTestNull()
+    {
+        _ = Assert.ThrowsException<ArgumentNullException>(() => new Settings().SubContentHeight = null);
     }
 
     [TestMethod]

--- a/ThScoreFileConverter.Tests/TestData/below-main-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/below-main-content-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <MainContentHeight>239</MainContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/below-sub-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/below-sub-content-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <SubContentHeight>79</SubContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/below-window-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/below-window-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <WindowHeight>479</WindowHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/below-window-width.xml
+++ b/ThScoreFileConverter.Tests/TestData/below-window-width.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <WindowWidth>479</WindowWidth>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/empty-main-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/empty-main-content-height.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <MainContentHeight />
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/empty-sub-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/empty-sub-content-height.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <SubContentHeight />
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/empty-window-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/empty-window-height.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <WindowHeight />
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/empty-window-width.xml
+++ b/ThScoreFileConverter.Tests/TestData/empty-window-width.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <WindowWidth />
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/invalid-main-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/invalid-main-content-height.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <MainContentHeight>abc</MainContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/invalid-sub-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/invalid-sub-content-height.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <SubContentHeight>abc</SubContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/invalid-window-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/invalid-window-height.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <WindowHeight>abc</WindowHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/invalid-window-width.xml
+++ b/ThScoreFileConverter.Tests/TestData/invalid-window-width.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <WindowWidth>abc</WindowWidth>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/negative-main-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/negative-main-content-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <MainContentHeight>-1</MainContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/negative-sub-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/negative-sub-content-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <SubContentHeight>-1</SubContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/negative-window-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/negative-window-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <WindowHeight>-1</WindowHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/negative-window-width.xml
+++ b/ThScoreFileConverter.Tests/TestData/negative-window-width.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <WindowWidth>-1</WindowWidth>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/no-optional-settings.xml
+++ b/ThScoreFileConverter.Tests/TestData/no-optional-settings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/zero-main-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/zero-main-content-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <MainContentHeight>0</MainContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/zero-sub-content-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/zero-sub-content-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <SubContentHeight>0</SubContentHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/zero-window-height.xml
+++ b/ThScoreFileConverter.Tests/TestData/zero-window-height.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <WindowHeight>0</WindowHeight>
+</Settings>

--- a/ThScoreFileConverter.Tests/TestData/zero-window-width.xml
+++ b/ThScoreFileConverter.Tests/TestData/zero-window-width.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings xmlns="http://schemas.datacontract.org/2004/07/ThScoreFileConverter">
+  <LastTitle>TH06</LastTitle>
+  <Dictionary xmlns:d2p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+      <d2p1:Key>TH06</d2p1:Key>
+      <d2p1:Value>
+        <BestShotDirectory />
+        <HideUntriedCards>false</HideUntriedCards>
+        <ImageOutputDirectory />
+        <OutputDirectory />
+        <ScoreFile />
+        <TemplateFiles />
+      </d2p1:Value>
+    </d2p1:KeyValueOfstringSettingsPerTitlewSAbBC2S>
+  </Dictionary>
+  <WindowWidth>0</WindowWidth>
+</Settings>

--- a/ThScoreFileConverter.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/ThScoreFileConverter.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -80,6 +80,34 @@ public class MainWindowViewModelTests
     }
 
     [TestMethod]
+    public void MinWidthTest()
+    {
+        using var window = CreateViewModel();
+        Assert.AreEqual(Settings.WindowMinWidth, window.MinWidth);
+    }
+
+    [TestMethod]
+    public void MinHeightTest()
+    {
+        using var window = CreateViewModel();
+        Assert.AreEqual(Settings.WindowMinHeight, window.MinHeight);
+    }
+
+    [TestMethod]
+    public void MainContentMinHeightTest()
+    {
+        using var window = CreateViewModel();
+        Assert.AreEqual(Settings.MainContentMinHeight, window.MainContentMinHeight);
+    }
+
+    [TestMethod]
+    public void SubContentMinHeightTest()
+    {
+        using var window = CreateViewModel();
+        Assert.AreEqual(Settings.SubContentMinHeight, window.SubContentMinHeight);
+    }
+
+    [TestMethod]
     public void TitleTest()
     {
         using var window = CreateViewModel();

--- a/ThScoreFileConverter/App.xaml
+++ b/ThScoreFileConverter/App.xaml
@@ -29,15 +29,27 @@
             <Setter Property="SizeToContent"
                     Value="WidthAndHeight"/>
         </Style>
+        <Style x:Key="HorizontalSeparatorStyle"
+               BasedOn="{StaticResource {x:Type Separator}}"
+               TargetType="{x:Type Separator}">
+            <Setter Property="Margin"
+                    Value="0,5"/>
+            <Setter Property="Opacity"
+                    Value="0"/>
+        </Style>
+        <Style x:Key="VerticalSeparatorStyle"
+               BasedOn="{StaticResource {x:Type Separator}}"
+               TargetType="{x:Type Separator}">
+            <Setter Property="Margin"
+                    Value="2,0"/>
+            <Setter Property="Opacity"
+                    Value="0"/>
+        </Style>
         <Style x:Key="HorizontalStackPanelStyle"
                TargetType="{x:Type StackPanel}">
             <Style.Resources>
-                <Style TargetType="Separator">
-                    <Setter Property="Margin"
-                            Value="2,0"/>
-                    <Setter Property="Opacity"
-                            Value="0"/>
-                </Style>
+                <Style BasedOn="{StaticResource VerticalSeparatorStyle}"
+                       TargetType="{x:Type Separator}"/>
             </Style.Resources>
             <Setter Property="Orientation"
                     Value="Horizontal"/>
@@ -45,12 +57,8 @@
         <Style x:Key="VerticalStackPanelStyle"
                TargetType="{x:Type StackPanel}">
             <Style.Resources>
-                <Style TargetType="Separator">
-                    <Setter Property="Margin"
-                            Value="0,5"/>
-                    <Setter Property="Opacity"
-                            Value="0"/>
-                </Style>
+                <Style BasedOn="{StaticResource HorizontalSeparatorStyle}"
+                       TargetType="{x:Type Separator}"/>
             </Style.Resources>
             <Setter Property="Orientation"
                     Value="Vertical"/>

--- a/ThScoreFileConverter/App.xaml
+++ b/ThScoreFileConverter/App.xaml
@@ -29,6 +29,16 @@
             <Setter Property="SizeToContent"
                     Value="WidthAndHeight"/>
         </Style>
+        <Style x:Key="HorizontalGridSplitterStyle"
+               BasedOn="{StaticResource {x:Type GridSplitter}}"
+               TargetType="{x:Type GridSplitter}">
+            <Setter Property="Height"
+                    Value="10"/>
+            <Setter Property="HorizontalAlignment"
+                    Value="Stretch"/>
+            <Setter Property="ShowsPreview"
+                    Value="True"/>
+        </Style>
         <Style x:Key="HorizontalSeparatorStyle"
                BasedOn="{StaticResource {x:Type Separator}}"
                TargetType="{x:Type Separator}">

--- a/ThScoreFileConverter/ISettings.cs
+++ b/ThScoreFileConverter/ISettings.cs
@@ -49,6 +49,26 @@ public interface ISettings
     bool? OutputNumberGroupSeparator { get; set; }
 
     /// <summary>
+    /// Gets or sets the width of the main window.
+    /// </summary>
+    double? WindowWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the main window.
+    /// </summary>
+    double? WindowHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the main content area in the main window.
+    /// </summary>
+    double? MainContentHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the height of the sub content area in the main window.
+    /// </summary>
+    double? SubContentHeight { get; set; }
+
+    /// <summary>
     /// Loads the settings from the specified XML file.
     /// </summary>
     /// <param name="path">The path of the XML file to load.</param>

--- a/ThScoreFileConverter/Settings.cs
+++ b/ThScoreFileConverter/Settings.cs
@@ -39,6 +39,10 @@ public sealed class Settings : ISettings, INotifyPropertyChanged
     private int? inputCodePageId;
     private int? outputCodePageId;
     private string? language;
+    private double? windowWidth;
+    private double? windowHeight;
+    private double? mainContentHeight;
+    private double? subContentHeight;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Settings"/> class.
@@ -53,6 +57,10 @@ public sealed class Settings : ISettings, INotifyPropertyChanged
         this.inputCodePageId = 65001;
         this.outputCodePageId = 65001;
         this.language = CultureInfo.InvariantCulture.Name;
+        this.windowWidth = WindowMinWidth;
+        this.windowHeight = WindowMinHeight;
+        this.mainContentHeight = MainContentMinHeight;
+        this.subContentHeight = SubContentMinHeight;
     }
 
     /// <inheritdoc/>
@@ -67,6 +75,26 @@ public sealed class Settings : ISettings, INotifyPropertyChanged
     /// Gets the maximum font size for this application.
     /// </summary>
     public static double MaxFontSize { get; } = 72;
+
+    /// <summary>
+    /// Gets the minimum width of the main window.
+    /// </summary>
+    public static double WindowMinWidth { get; } = 480;
+
+    /// <summary>
+    /// Gets the minimum height of the main window.
+    /// </summary>
+    public static double WindowMinHeight { get; } = 480;
+
+    /// <summary>
+    /// Gets the minimum height of the main content area in the main window.
+    /// </summary>
+    public static double MainContentMinHeight { get; } = 240;
+
+    /// <summary>
+    /// Gets the minimum height of the sub content area in the main window.
+    /// </summary>
+    public static double SubContentMinHeight { get; } = 80;
 
     /// <inheritdoc/>
     [DataMember(Order = 0)]
@@ -145,6 +173,38 @@ public sealed class Settings : ISettings, INotifyPropertyChanged
         }
     }
 
+    /// <inheritdoc/>
+    [DataMember(Order = 8)]
+    public double? WindowWidth
+    {
+        get => this.windowWidth;
+        set => this.SetProperty(ref this.windowWidth, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(Order = 9)]
+    public double? WindowHeight
+    {
+        get => this.windowHeight;
+        set => this.SetProperty(ref this.windowHeight, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(Order = 10)]
+    public double? MainContentHeight
+    {
+        get => this.mainContentHeight;
+        set => this.SetProperty(ref this.mainContentHeight, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(Order = 11)]
+    public double? SubContentHeight
+    {
+        get => this.subContentHeight;
+        set => this.SetProperty(ref this.subContentHeight, value);
+    }
+
     /// <summary>
     /// Gets the number of <see cref="SettingsPerTitle"/> instances.
     /// </summary>
@@ -201,6 +261,15 @@ public sealed class Settings : ISettings, INotifyPropertyChanged
                 this.OutputCodePageId = settings.OutputCodePageId.Value;
             if (settings.Language is not null)
                 this.Language = settings.Language;
+
+            if (settings.WindowWidth.HasValue && (settings.WindowWidth.Value >= WindowMinWidth))
+                this.WindowWidth = settings.WindowWidth.Value;
+            if (settings.WindowHeight.HasValue && (settings.WindowHeight.Value >= WindowMinHeight))
+                this.WindowHeight = settings.WindowHeight.Value;
+            if (settings.MainContentHeight.HasValue && (settings.MainContentHeight.Value >= MainContentMinHeight))
+                this.MainContentHeight = settings.MainContentHeight.Value;
+            if (settings.SubContentHeight.HasValue && (settings.SubContentHeight.Value >= SubContentMinHeight))
+                this.SubContentHeight = settings.SubContentHeight.Value;
         }
         catch (FileNotFoundException)
         {

--- a/ThScoreFileConverter/ViewModels/MainWindowViewModel.cs
+++ b/ThScoreFileConverter/ViewModels/MainWindowViewModel.cs
@@ -94,6 +94,20 @@ internal class MainWindowViewModel : BindableBase, IDisposable
 
         var rpMode = ReactivePropertyMode.DistinctUntilChanged;
 
+        this.MinWidth = Settings.WindowMinWidth;
+        this.Width = this.settings.ToReactivePropertySlimAsSynchronized(
+            x => x.WindowWidth, value => (double)value!, value => value, rpMode);
+        this.MinHeight = Settings.WindowMinHeight;
+        this.Height = this.settings.ToReactivePropertySlimAsSynchronized(
+            x => x.WindowHeight, value => (double)value!, value => value, rpMode);
+
+        this.MainContentMinHeight = Settings.MainContentMinHeight;
+        this.MainContentHeight = this.settings.ToReactivePropertySlimAsSynchronized(
+            x => x.MainContentHeight, value => new GridLength((double)value!, GridUnitType.Star), value => value.Value, rpMode);
+        this.SubContentMinHeight = Settings.SubContentMinHeight;
+        this.SubContentHeight = this.settings.ToReactivePropertySlimAsSynchronized(
+            x => x.SubContentHeight, value => new GridLength((double)value!, GridUnitType.Star), value => value.Value, rpMode);
+
         this.Title = Assembly.GetExecutingAssembly().GetName().Name ?? nameof(ThScoreFileConverter);
         this.Works = Definitions.Works;
         this.IsIdle = new ReactivePropertySlim<bool>(true);
@@ -213,6 +227,46 @@ internal class MainWindowViewModel : BindableBase, IDisposable
     }
 
     #region Properties to bind a view
+
+    /// <summary>
+    /// Gets the minimum width of the window.
+    /// </summary>
+    public double MinWidth { get; }
+
+    /// <summary>
+    /// Gets the current width of the window.
+    /// </summary>
+    public ReactivePropertySlim<double> Width { get; }
+
+    /// <summary>
+    /// Gets the minimum height of the window.
+    /// </summary>
+    public double MinHeight { get; }
+
+    /// <summary>
+    /// Gets the current height of the window.
+    /// </summary>
+    public ReactivePropertySlim<double> Height { get; }
+
+    /// <summary>
+    /// Gets the minimum height of the main content.
+    /// </summary>
+    public double MainContentMinHeight { get; }
+
+    /// <summary>
+    /// Gets the current height of the main content.
+    /// </summary>
+    public ReactivePropertySlim<GridLength> MainContentHeight { get; }
+
+    /// <summary>
+    /// Gets the minimum height of the sub content.
+    /// </summary>
+    public double SubContentMinHeight { get; }
+
+    /// <summary>
+    /// Gets the current height of the sub content.
+    /// </summary>
+    public ReactivePropertySlim<GridLength> SubContentHeight { get; }
 
     /// <summary>
     /// Gets a title string.
@@ -416,6 +470,10 @@ internal class MainWindowViewModel : BindableBase, IDisposable
             this.LastWorkNumber.Dispose();
             this.IsIdle.Dispose();
             this.CurrentSetting.Dispose();
+            this.SubContentHeight.Dispose();
+            this.MainContentHeight.Dispose();
+            this.Height.Dispose();
+            this.Width.Dispose();
             this.disposables.Dispose();
         }
 

--- a/ThScoreFileConverter/Views/MainWindow.xaml
+++ b/ThScoreFileConverter/Views/MainWindow.xaml
@@ -9,11 +9,14 @@
         lex:LocalizeDictionary.DesignCulture="ja-JP"
         lex:LocalizeDictionary.Provider="{x:Static m:LocalizationProvider.Instance}"
         IsEnabled="{Binding IsIdle.Value}"
-        ResizeMode="CanMinimize"
-        SizeToContent="WidthAndHeight"
+        Height="480"
+        MinHeight="480"
+        MinWidth="480"
+        ResizeMode="CanResizeWithGrip"
         Style="{StaticResource WindowStyleKey}"
         Title="{Binding Title}"
-        UseLayoutRounding="True">
+        UseLayoutRounding="True"
+        Width="480">
 
     <xb:Interaction.Triggers>
         <xb:EventTrigger EventName="Closed">
@@ -21,9 +24,8 @@
         </xb:EventTrigger>
     </xb:Interaction.Triggers>
 
-    <StackPanel Margin="10"
-                Style="{StaticResource VerticalStackPanelStyle}">
-        <Grid>
+    <DockPanel Margin="12">
+        <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -64,248 +66,256 @@
             <Label Grid.Column="1"
                    Content="{Binding SupportedVersions}"/>
         </Grid>
+        <Separator DockPanel.Dock="Top"
+                   Style="{StaticResource HorizontalSeparatorStyle}"/>
 
-        <Separator/>
+        <StackPanel DockPanel.Dock="Bottom"
+                    HorizontalAlignment="Right"
+                    Style="{StaticResource HorizontalStackPanelStyle}">
+            <Button Command="{Binding OpenSettingWindowCommand}"
+                    Content="{lex:Loc ViewsMainWindowButtonSetting}"/>
+            <Separator/>
+            <Button Command="{Binding OpenAboutWindowCommand}"
+                    Content="{lex:Loc ViewsMainWindowButtonAbout}"/>
+        </StackPanel>
+        <Separator DockPanel.Dock="Bottom"
+                   Style="{StaticResource HorizontalSeparatorStyle}"/>
 
         <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="250"/>
-                <ColumnDefinition Width="auto"/>
-            </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
+                <RowDefinition Height="3*"/>
                 <RowDefinition Height="auto"/>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="auto"/>
-                <RowDefinition Height="auto"/>
+                <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Grid.Resources>
-                <Style BasedOn="{StaticResource {x:Type Button}}"
-                       TargetType="{x:Type Button}">
-                    <Setter Property="Margin"
-                            Value="5,2,0,2"/>
-                </Style>
-                <Style BasedOn="{StaticResource {x:Type ListBox}}"
-                       TargetType="{x:Type ListBox}">
-                    <Setter Property="Margin"
-                            Value="0,2"/>
-                </Style>
-                <Style BasedOn="{StaticResource {x:Type TextBox}}"
-                       TargetType="{x:Type TextBox}">
-                    <Setter Property="Margin"
-                            Value="0,2"/>
-                </Style>
-            </Grid.Resources>
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="auto"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                </Grid.RowDefinitions>
 
-            <Label Grid.Column="0"
-                   Grid.Row="0"
-                   Content="{lex:Loc ViewsMainWindowLabelScore}"
-                   HorizontalAlignment="Left"
-                   Target="{Binding ElementName=ScoreTextBox, Mode=OneWay}"
-                   VerticalAlignment="Center"/>
-            <TextBox x:Name="ScoreTextBox"
-                     Grid.Column="1"
-                     Grid.Row="0"
-                     IsReadOnly="True"
-                     Text="{Binding ScoreFile.Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                     VerticalAlignment="Center">
-                <xb:Interaction.Behaviors>
-                    <i:UIElementDropBehavior DropCommand="{Binding DropScoreFileCommand}"
-                                             PreviewDragEnterCommand="{Binding DraggingCommand}"
-                                             PreviewDragOverCommand="{Binding DraggingCommand}"/>
-                </xb:Interaction.Behaviors>
-            </TextBox>
-            <Button Grid.Column="2"
-                    Grid.Row="0"
-                    Content="{lex:Loc ViewsMainWindowButtonOpen}"
-                    VerticalAlignment="Center">
-                <xb:Interaction.Triggers>
-                    <xb:EventTrigger EventName="Click">
-                        <i:OpenFileDialogAction Filter="{lex:Loc ScoreFileFilter}"
-                                                InitialDirectory="{Binding OpenScoreFileDialogInitialDirectory.Value}"
-                                                OkCommand="{Binding SelectScoreFileCommand}"
-                                                Owner="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"/>
-                    </xb:EventTrigger>
-                </xb:Interaction.Triggers>
-            </Button>
+                <Grid.Resources>
+                    <Style BasedOn="{StaticResource {x:Type Button}}"
+                           TargetType="{x:Type Button}">
+                        <Setter Property="Margin"
+                                Value="5,2,0,2"/>
+                    </Style>
+                    <Style BasedOn="{StaticResource {x:Type ListBox}}"
+                           TargetType="{x:Type ListBox}">
+                        <Setter Property="Margin"
+                                Value="0,2"/>
+                    </Style>
+                    <Style BasedOn="{StaticResource {x:Type TextBox}}"
+                           TargetType="{x:Type TextBox}">
+                        <Setter Property="Margin"
+                                Value="0,2"/>
+                    </Style>
+                </Grid.Resources>
 
-            <Label Grid.Column="0"
-                   Grid.Row="1"
-                   Content="{lex:Loc ViewsMainWindowLabelBestShot}"
-                   HorizontalAlignment="Left"
-                   IsEnabled="{Binding CanHandleBestShot}"
-                   Target="{Binding ElementName=BestShotTextBox, Mode=OneWay}"
-                   VerticalAlignment="Center"/>
-            <TextBox x:Name="BestShotTextBox"
-                     Grid.Column="1"
-                     Grid.Row="1"
-                     IsEnabled="{Binding CanHandleBestShot}"
-                     IsReadOnly="True"
-                     Text="{Binding BestShotDirectory.Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                     VerticalAlignment="Center">
-                <xb:Interaction.Behaviors>
-                    <i:UIElementDropBehavior DropCommand="{Binding DropBestShotDirectoryCommand}"
-                                             PreviewDragEnterCommand="{Binding DraggingCommand}"
-                                             PreviewDragOverCommand="{Binding DraggingCommand}"/>
-                </xb:Interaction.Behaviors>
-            </TextBox>
-            <Button Grid.Column="2"
-                    Grid.Row="1"
-                    Content="{lex:Loc ViewsMainWindowButtonOpen}"
-                    IsEnabled="{Binding CanHandleBestShot}"
-                    VerticalAlignment="Center">
-                <xb:Interaction.Triggers>
-                    <xb:EventTrigger EventName="Click">
-                        <i:FolderBrowserDialogAction Description="{lex:Loc MessageSelectBestShotDirectory}"
-                                                     OkCommand="{Binding SelectBestShotDirectoryCommand}"
-                                                     Owner="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
-                                                     SelectedPath="{Binding Text, ElementName=BestShotTextBox}"
-                                                     ShowNewFolderButton="False"/>
-                    </xb:EventTrigger>
-                </xb:Interaction.Triggers>
-            </Button>
-
-            <Label Grid.Column="0"
-                   Grid.Row="2"
-                   Content="{lex:Loc ViewsMainWindowLabelTemplates}"
-                   HorizontalAlignment="Left"
-                   Target="{Binding ElementName=TemplateListBox, Mode=OneWay}"
-                   VerticalAlignment="Top"/>
-            <ListBox x:Name="TemplateListBox"
-                     Grid.Column="1"
-                     Grid.Row="2"
-                     ScrollViewer.HorizontalScrollBarVisibility="Visible"
-                     ScrollViewer.VerticalScrollBarVisibility="Auto"
-                     AllowDrop="True"
-                     Height="100"
-                     ItemsSource="{Binding TemplateFiles.Value}"
-                     SelectionMode="Multiple"
-                     VerticalAlignment="Top">
-                <xb:Interaction.Behaviors>
-                    <i:UIElementDropBehavior DropCommand="{Binding DropTemplateFilesCommand}"
-                                             PreviewDragEnterCommand="{Binding DraggingCommand}"
-                                             PreviewDragOverCommand="{Binding DraggingCommand}"/>
-                </xb:Interaction.Behaviors>
-                <xb:Interaction.Triggers>
-                    <xb:EventTrigger EventName="SelectionChanged">
-                        <xb:InvokeCommandAction Command="{Binding TemplateFilesSelectionChangedCommand}"/>
-                    </xb:EventTrigger>
-                </xb:Interaction.Triggers>
-            </ListBox>
-            <StackPanel Grid.Column="2"
-                        Grid.Row="2">
-                <Button Content="{lex:Loc ViewsMainWindowButtonAdd}">
+                <Label Grid.Column="0"
+                       Grid.Row="0"
+                       Content="{lex:Loc ViewsMainWindowLabelScore}"
+                       HorizontalAlignment="Left"
+                       Target="{Binding ElementName=ScoreTextBox, Mode=OneWay}"
+                       VerticalAlignment="Center"/>
+                <TextBox x:Name="ScoreTextBox"
+                         Grid.Column="1"
+                         Grid.Row="0"
+                         IsReadOnly="True"
+                         Text="{Binding ScoreFile.Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                         VerticalAlignment="Center">
+                    <xb:Interaction.Behaviors>
+                        <i:UIElementDropBehavior DropCommand="{Binding DropScoreFileCommand}"
+                                                 PreviewDragEnterCommand="{Binding DraggingCommand}"
+                                                 PreviewDragOverCommand="{Binding DraggingCommand}"/>
+                    </xb:Interaction.Behaviors>
+                </TextBox>
+                <Button Grid.Column="2"
+                        Grid.Row="0"
+                        Content="{lex:Loc ViewsMainWindowButtonOpen}"
+                        VerticalAlignment="Center">
                     <xb:Interaction.Triggers>
                         <xb:EventTrigger EventName="Click">
-                            <i:OpenFileDialogAction Filter="{lex:Loc TemplateFileFilter}"
-                                                    InitialDirectory="{Binding OpenTemplateFilesDialogInitialDirectory.Value}"
-                                                    Multiselect="True"
-                                                    OkCommand="{Binding AddTemplateFilesCommand}"
+                            <i:OpenFileDialogAction Filter="{lex:Loc ScoreFileFilter}"
+                                                    InitialDirectory="{Binding OpenScoreFileDialogInitialDirectory.Value}"
+                                                    OkCommand="{Binding SelectScoreFileCommand}"
                                                     Owner="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"/>
                         </xb:EventTrigger>
                     </xb:Interaction.Triggers>
                 </Button>
-                <Button Command="{Binding DeleteTemplateFilesCommand}"
-                        CommandParameter="{Binding SelectedItems, ElementName=TemplateListBox}"
-                        Content="{lex:Loc ViewsMainWindowButtonRemove}"/>
-                <Button Command="{Binding DeleteAllTemplateFilesCommand}"
-                        Content="{lex:Loc ViewsMainWindowButtonRemoveAll}"/>
-            </StackPanel>
 
-            <Label Grid.Column="0"
-                   Grid.Row="3"
-                   Content="{lex:Loc ViewsMainWindowLabelOutput}"
-                   HorizontalAlignment="Left"
-                   Target="{Binding ElementName=OutputTextBox, Mode=OneWay}"
-                   VerticalAlignment="Center"/>
-            <TextBox x:Name="OutputTextBox"
-                     Grid.Column="1"
-                     Grid.Row="3"
+                <Label Grid.Column="0"
+                       Grid.Row="1"
+                       Content="{lex:Loc ViewsMainWindowLabelBestShot}"
+                       HorizontalAlignment="Left"
+                       IsEnabled="{Binding CanHandleBestShot}"
+                       Target="{Binding ElementName=BestShotTextBox, Mode=OneWay}"
+                       VerticalAlignment="Center"/>
+                <TextBox x:Name="BestShotTextBox"
+                         Grid.Column="1"
+                         Grid.Row="1"
+                         IsEnabled="{Binding CanHandleBestShot}"
+                         IsReadOnly="True"
+                         Text="{Binding BestShotDirectory.Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                         VerticalAlignment="Center">
+                    <xb:Interaction.Behaviors>
+                        <i:UIElementDropBehavior DropCommand="{Binding DropBestShotDirectoryCommand}"
+                                                 PreviewDragEnterCommand="{Binding DraggingCommand}"
+                                                 PreviewDragOverCommand="{Binding DraggingCommand}"/>
+                    </xb:Interaction.Behaviors>
+                </TextBox>
+                <Button Grid.Column="2"
+                        Grid.Row="1"
+                        Content="{lex:Loc ViewsMainWindowButtonOpen}"
+                        IsEnabled="{Binding CanHandleBestShot}"
+                        VerticalAlignment="Center">
+                    <xb:Interaction.Triggers>
+                        <xb:EventTrigger EventName="Click">
+                            <i:FolderBrowserDialogAction Description="{lex:Loc MessageSelectBestShotDirectory}"
+                                                         OkCommand="{Binding SelectBestShotDirectoryCommand}"
+                                                         Owner="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
+                                                         SelectedPath="{Binding Text, ElementName=BestShotTextBox}"
+                                                         ShowNewFolderButton="False"/>
+                        </xb:EventTrigger>
+                    </xb:Interaction.Triggers>
+                </Button>
+
+                <Label Grid.Column="0"
+                       Grid.Row="2"
+                       Content="{lex:Loc ViewsMainWindowLabelTemplates}"
+                       HorizontalAlignment="Left"
+                       Target="{Binding ElementName=TemplateListBox, Mode=OneWay}"
+                       VerticalAlignment="Top"/>
+                <ListBox x:Name="TemplateListBox"
+                         Grid.Column="1"
+                         Grid.Row="2"
+                         ScrollViewer.HorizontalScrollBarVisibility="Visible"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         AllowDrop="True"
+                         ItemsSource="{Binding TemplateFiles.Value}"
+                         SelectionMode="Multiple">
+                    <xb:Interaction.Behaviors>
+                        <i:UIElementDropBehavior DropCommand="{Binding DropTemplateFilesCommand}"
+                                                 PreviewDragEnterCommand="{Binding DraggingCommand}"
+                                                 PreviewDragOverCommand="{Binding DraggingCommand}"/>
+                    </xb:Interaction.Behaviors>
+                    <xb:Interaction.Triggers>
+                        <xb:EventTrigger EventName="SelectionChanged">
+                            <xb:InvokeCommandAction Command="{Binding TemplateFilesSelectionChangedCommand}"/>
+                        </xb:EventTrigger>
+                    </xb:Interaction.Triggers>
+                </ListBox>
+                <StackPanel Grid.Column="2"
+                            Grid.Row="2">
+                    <Button Content="{lex:Loc ViewsMainWindowButtonAdd}">
+                        <xb:Interaction.Triggers>
+                            <xb:EventTrigger EventName="Click">
+                                <i:OpenFileDialogAction Filter="{lex:Loc TemplateFileFilter}"
+                                                        InitialDirectory="{Binding OpenTemplateFilesDialogInitialDirectory.Value}"
+                                                        Multiselect="True"
+                                                        OkCommand="{Binding AddTemplateFilesCommand}"
+                                                        Owner="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"/>
+                            </xb:EventTrigger>
+                        </xb:Interaction.Triggers>
+                    </Button>
+                    <Button Command="{Binding DeleteTemplateFilesCommand}"
+                            CommandParameter="{Binding SelectedItems, ElementName=TemplateListBox}"
+                            Content="{lex:Loc ViewsMainWindowButtonRemove}"/>
+                    <Button Command="{Binding DeleteAllTemplateFilesCommand}"
+                            Content="{lex:Loc ViewsMainWindowButtonRemoveAll}"/>
+                </StackPanel>
+
+                <Label Grid.Column="0"
+                       Grid.Row="3"
+                       Content="{lex:Loc ViewsMainWindowLabelOutput}"
+                       HorizontalAlignment="Left"
+                       Target="{Binding ElementName=OutputTextBox, Mode=OneWay}"
+                       VerticalAlignment="Center"/>
+                <TextBox x:Name="OutputTextBox"
+                         Grid.Column="1"
+                         Grid.Row="3"
+                         IsReadOnly="True"
+                         Text="{Binding OutputDirectory.Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                         VerticalAlignment="Center">
+                    <xb:Interaction.Behaviors>
+                        <i:UIElementDropBehavior DropCommand="{Binding DropOutputDirectoryCommand}"
+                                                 PreviewDragEnterCommand="{Binding DraggingCommand}"
+                                                 PreviewDragOverCommand="{Binding DraggingCommand}"/>
+                    </xb:Interaction.Behaviors>
+                </TextBox>
+                <Button Grid.Column="2"
+                        Grid.Row="3"
+                        Content="{lex:Loc ViewsMainWindowButtonOpen}"
+                        VerticalAlignment="Center">
+                    <xb:Interaction.Triggers>
+                        <xb:EventTrigger EventName="Click">
+                            <i:FolderBrowserDialogAction Description="{lex:Loc MessageSelectOutputDirectory}"
+                                                         OkCommand="{Binding SelectOutputDirectoryCommand}"
+                                                         Owner="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
+                                                         SelectedPath="{Binding Text, ElementName=OutputTextBox}"/>
+                        </xb:EventTrigger>
+                    </xb:Interaction.Triggers>
+                </Button>
+
+                <Label Grid.Column="0"
+                       Grid.Row="4"
+                       Content="{lex:Loc ViewsMainWindowLabelImageOutput}"
+                       HorizontalAlignment="Left"
+                       IsEnabled="{Binding CanHandleBestShot}"
+                       Target="{Binding ElementName=ImageOutputTextBox, Mode=OneWay}"
+                       VerticalAlignment="Center"/>
+                <TextBox x:Name="ImageOutputTextBox"
+                         Grid.Column="1"
+                         Grid.Row="4"
+                         IsEnabled="{Binding CanHandleBestShot}"
+                         Text="{Binding ImageOutputDirectory.Value, UpdateSourceTrigger=PropertyChanged}"
+                         VerticalAlignment="Center"/>
+                <CheckBox Grid.Column="1"
+                          Grid.ColumnSpan="2"
+                          Grid.Row="5"
+                          Content="{lex:Loc ViewsMainWindowCheckBoxHideUntriedCardNames}"
+                          IsChecked="{Binding HidesUntriedCards.Value}"
+                          IsEnabled="{Binding CanReplaceCardNames}"/>
+
+                <Separator Grid.ColumnSpan="3"
+                           Grid.Row="6"
+                           Style="{StaticResource HorizontalSeparatorStyle}"/>
+
+                <Button Grid.ColumnSpan="3"
+                        Grid.Row="7"
+                        Command="{Binding ConvertCommand}"
+                        Content="{lex:Loc ViewsMainWindowButtonConvert}"
+                        HorizontalAlignment="Center"
+                        IsDefault="True"
+                        MinWidth="100"/>
+            </Grid>
+
+            <Separator Grid.Row="1"
+                       Style="{StaticResource HorizontalSeparatorStyle}"/>
+
+            <TextBox Grid.Row="2"
+                     AllowDrop="False"
+                     FontSize="10"
                      IsReadOnly="True"
-                     Text="{Binding OutputDirectory.Value, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                     VerticalAlignment="Center">
+                     IsUndoEnabled="False"
+                     Text="{Binding Log.Value, Mode=OneWay, NotifyOnTargetUpdated=True}"
+                     TextWrapping="Wrap"
+                     VerticalScrollBarVisibility="Visible">
                 <xb:Interaction.Behaviors>
-                    <i:UIElementDropBehavior DropCommand="{Binding DropOutputDirectoryCommand}"
-                                             PreviewDragEnterCommand="{Binding DraggingCommand}"
-                                             PreviewDragOverCommand="{Binding DraggingCommand}"/>
+                    <i:TextBoxBaseScrollBehavior AutoScrollToEnd="True"/>
                 </xb:Interaction.Behaviors>
             </TextBox>
-            <Button Grid.Column="2"
-                    Grid.Row="3"
-                    Content="{lex:Loc ViewsMainWindowButtonOpen}"
-                    VerticalAlignment="Center">
-                <xb:Interaction.Triggers>
-                    <xb:EventTrigger EventName="Click">
-                        <i:FolderBrowserDialogAction Description="{lex:Loc MessageSelectOutputDirectory}"
-                                                     OkCommand="{Binding SelectOutputDirectoryCommand}"
-                                                     Owner="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}"
-                                                     SelectedPath="{Binding Text, ElementName=OutputTextBox}"/>
-                    </xb:EventTrigger>
-                </xb:Interaction.Triggers>
-            </Button>
-
-            <Label Grid.Column="0"
-                   Grid.Row="4"
-                   Content="{lex:Loc ViewsMainWindowLabelImageOutput}"
-                   HorizontalAlignment="Left"
-                   IsEnabled="{Binding CanHandleBestShot}"
-                   Target="{Binding ElementName=ImageOutputTextBox, Mode=OneWay}"
-                   VerticalAlignment="Center"/>
-            <TextBox x:Name="ImageOutputTextBox"
-                     Grid.Column="1"
-                     Grid.Row="4"
-                     IsEnabled="{Binding CanHandleBestShot}"
-                     Text="{Binding ImageOutputDirectory.Value, UpdateSourceTrigger=PropertyChanged}"
-                     VerticalAlignment="Center"/>
-            <CheckBox Grid.Column="1"
-                      Grid.ColumnSpan="2"
-                      Grid.Row="5"
-                      Content="{lex:Loc ViewsMainWindowCheckBoxHideUntriedCardNames}"
-                      IsChecked="{Binding HidesUntriedCards.Value}"
-                      IsEnabled="{Binding CanReplaceCardNames}"/>
         </Grid>
-
-        <Separator/>
-
-        <Button Command="{Binding ConvertCommand}"
-                Content="{lex:Loc ViewsMainWindowButtonConvert}"
-                HorizontalAlignment="Center"
-                IsDefault="True"
-                MinWidth="100"/>
-
-        <Separator/>
-
-        <TextBox AllowDrop="False"
-                 FontSize="10"
-                 Height="70"
-                 IsReadOnly="True"
-                 IsUndoEnabled="False"
-                 Text="{Binding Log.Value, Mode=OneWay, NotifyOnTargetUpdated=True}"
-                 TextWrapping="Wrap"
-                 VerticalScrollBarVisibility="Visible">
-            <xb:Interaction.Behaviors>
-                <i:TextBoxBaseScrollBehavior AutoScrollToEnd="True"/>
-            </xb:Interaction.Behaviors>
-        </TextBox>
-
-        <Separator/>
-
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="auto"/>
-            </Grid.ColumnDefinitions>
-            <StackPanel Grid.Column="1"
-                        Style="{StaticResource HorizontalStackPanelStyle}">
-                <Button Command="{Binding OpenSettingWindowCommand}"
-                        Content="{lex:Loc ViewsMainWindowButtonSetting}"/>
-                <Separator/>
-                <Button Command="{Binding OpenAboutWindowCommand}"
-                        Content="{lex:Loc ViewsMainWindowButtonAbout}"/>
-            </StackPanel>
-        </Grid>
-    </StackPanel>
+    </DockPanel>
 </Window>

--- a/ThScoreFileConverter/Views/MainWindow.xaml
+++ b/ThScoreFileConverter/Views/MainWindow.xaml
@@ -83,9 +83,11 @@
 
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="3*"/>
+                <RowDefinition Height="3*"
+                               MinHeight="240"/>
                 <RowDefinition Height="auto"/>
-                <RowDefinition Height="*"/>
+                <RowDefinition Height="*"
+                               MinHeight="80"/>
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">
@@ -301,8 +303,8 @@
                         MinWidth="100"/>
             </Grid>
 
-            <Separator Grid.Row="1"
-                       Style="{StaticResource HorizontalSeparatorStyle}"/>
+            <GridSplitter Grid.Row="1"
+                          Style="{StaticResource HorizontalGridSplitterStyle}"/>
 
             <TextBox Grid.Row="2"
                      AllowDrop="False"

--- a/ThScoreFileConverter/Views/MainWindow.xaml
+++ b/ThScoreFileConverter/Views/MainWindow.xaml
@@ -8,15 +8,15 @@
         xmlns:m="clr-namespace:ThScoreFileConverter.Models"
         lex:LocalizeDictionary.DesignCulture="ja-JP"
         lex:LocalizeDictionary.Provider="{x:Static m:LocalizationProvider.Instance}"
+        Height="{Binding Height.Value, Mode=TwoWay}"
         IsEnabled="{Binding IsIdle.Value}"
-        Height="480"
-        MinHeight="480"
-        MinWidth="480"
+        MinHeight="{Binding MinHeight}"
+        MinWidth="{Binding MinWidth}"
         ResizeMode="CanResizeWithGrip"
         Style="{StaticResource WindowStyleKey}"
         Title="{Binding Title}"
         UseLayoutRounding="True"
-        Width="480">
+        Width="{Binding Width.Value, Mode=TwoWay}">
 
     <xb:Interaction.Triggers>
         <xb:EventTrigger EventName="Closed">
@@ -83,11 +83,11 @@
 
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="3*"
-                               MinHeight="240"/>
+                <RowDefinition Height="{Binding MainContentHeight.Value, Mode=TwoWay}"
+                               MinHeight="{Binding MainContentMinHeight}"/>
                 <RowDefinition Height="auto"/>
-                <RowDefinition Height="*"
-                               MinHeight="80"/>
+                <RowDefinition Height="{Binding SubContentHeight.Value, Mode=TwoWay}"
+                               MinHeight="{Binding SubContentMinHeight}"/>
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">


### PR DESCRIPTION
Closes #302.

Not only the main window but also some UI elements can be resized, by dragging the grid splitter between the Convert button and the logging text box.
These resized values are saved into settings.xml and restored on the next startup.