### PR TITLE
Revert "Bump codecov/codecov-action from 3.1.5 to 4.0.1"

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -106,7 +106,7 @@ jobs:
       if: inputs.dotnet-configuration == 'Debug'
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v3.1.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: CoverageResults/coverage.${{ inputs.dotnet-target-framework }}.opencover.xml


### PR DESCRIPTION
Reverts y-iihoshi/ThScoreFileConverter#438 because codecov-action@v4 causes the following error:

> Error: Codecov token not found. Please provide Codecov token with -t flag.

even if my CI action passes the token as follows (unchanged since v3.1.5):

```yaml
    - name: Upload coverage to Codecov
      uses: codecov/codecov-action@v4.0.1
      with:
        token: ${{ secrets.CODECOV_TOKEN }}
        file: CoverageResults/coverage.${{ inputs.dotnet-target-framework }}.opencover.xml
      if: inputs.dotnet-configuration == 'Debug'
```